### PR TITLE
feat(ARCH-1218): Change page background color of Flask app to Orange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+
+- Added: Update page background color to orange. (#7)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,5 @@
 body {
-  background-color: #F3EBF6;
+  background-color: orange;
   font-family: 'Ubuntu', sans-serif;
 }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,27 @@
+# test_app.py — scaffolded by jira_to_code for ARCH-1218
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app  # noqa: E402
+import pytest  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_home_page(client):
+    """Verify that the home page loads correctly and has 200 status code."""
+    rv = client.get('/')
+    assert rv.status_code == 200
+
+
+def test_background_color_in_css(client):
+    """Verify that style.css defines the background-color as orange."""
+    rv = client.get('/static/css/style.css')
+    assert rv.status_code == 200
+    assert b'background-color: orange' in rv.data or b'background-color: #FFA500' in rv.data


### PR DESCRIPTION
# Implementation Plan — ARCH-1218

## Summary
This implementation plan addresses ticket ARCH-1218, which requires updating the background color of the main web page in the `flask-demo-app` to orange. We will modify the CSS definition in `static/css/style.css` to update the background color from its current value to orange, and write tests to ensure both the home page renders and the style sheet contains the updated orange background color.

## Language & Stack
- Language: Python
- Test framework: pytest
- Linter: flake8

## Steps

### Step 1 — Locate and Inspect Style Sheet
**AC:** "Find the required file (HTML template or CSS file)."
**What:** Verify the location of the stylesheet defined in `templates/page.html` which is linked to `static/css/style.css`. Inspect `static/css/style.css` to find the background-color definition of the body element.
**Files:**
  - Examine: `static/css/style.css`
  - Examine: `templates/page.html`

### Step 2 — Update Background Color to Orange
**AC:** "Change the background color of the page to Orange color."
**What:** Update the `background-color` property of the `body` tag inside `static/css/style.css` to `orange`.
**Files:**
  - Modify: `static/css/style.css`

### Step 3 — Update the Color Code in CSS
**AC:** "Update the color code."
**What:** Ensure that the color code is fully updated in `static/css/style.css` to refer to orange.
**Files:**
  - Modify: `static/css/style.css`

### Step 4 — Implement Tests for Background Color
**AC:** "Change the background color of the page to Orange color."
**What:** Create a new test suite under `tests/test_app.py` to assert that the home page renders successfully and that the stylesheet contains the `background-color: orange` definition.
**Files:**
  - Create: `tests/test_app.py`

## Dependencies Required
- pytest — framework for running tests
